### PR TITLE
added space at the beginning of Assignment

### DIFF
--- a/ttt-utils/lib/assignments.typ
+++ b/ttt-utils/lib/assignments.typ
@@ -207,7 +207,10 @@
   new-assignment
 
   body = {
-    if (number != none and number != "hide") { _get-a-nr(style: number) }
+    if (number != none and number != "hide") {
+      _get-a-nr(style: number)
+      [ ]
+    }
     body
   }
 


### PR DESCRIPTION
There is a small bug in that the `assignment` function does  not automatically display a space after the numbering, whereas the `question` function does:
<img width="433" height="226" alt="image" src="https://github.com/user-attachments/assets/9450bca0-ecd0-4031-8d17-347f3903daa7" />

This PR fixes it with a small change. I tested it to make sure this does not add an _extra_ space if I add one manually.