### PR TITLE
Rewrite the whole `random` module

### DIFF
--- a/ttt-utils/lib/assignments.typ
+++ b/ttt-utils/lib/assignments.typ
@@ -327,6 +327,9 @@
   points: auto,
   /// direction of the options. Gets passed to typst `stack` function.
   dir: ttb,
+  /// if true the choices will be shuffled. default: true
+  /// -> bool
+  shuffled: true,
 ) = {
   let answers = if (type(answers) == array ) { answers } else { (answers,) }
   answers = answers.map(entry => [#entry])
@@ -337,17 +340,23 @@
       #prompt
       #let choices = (..distractors, ..answers)
 
-      #let choices = shuffle(choices).map(choice => {
-        box(inset:(x:0.5em))[
-          #context {
-            let is-solution = is-solution-mode() and choice in answers
-            checkbox(fill: if is-solution { red }, tick: is-solution )
-          }
-        ]; choice
-      })
+      #context {
+        let shuffled-choices = if shuffled {
+             shuffle(choices, _question_counter.get())
+        } else {
+             choices
+        }
 
-      #stack(dir:dir, spacing: 1em, ..choices)
+        let is-sol-mode = is-solution-mode()
 
+        let final-choices = shuffled-choices.map(choice => {
+            let is-solution = is-sol-mode and choice in answers
+            box(inset:(x:0.5em))[
+              #checkbox(fill: if is-solution { red }, tick: is-solution )
+            ]; choice
+        })
+        stack(dir:dir, spacing: 1em, ..final-choices)
+      }
 
       // show hint if available.
       #if (hint != none) {

--- a/ttt-utils/lib/random.typ
+++ b/ttt-utils/lib/random.typ
@@ -1,16 +1,30 @@
-/// create a hash value from a seed for some content
-#let hash(value, seed) = {
-  array(bytes(repr(value))).fold(seed, (a,b) => (a.bit-lshift(1)).bit-xor(b))
+#import "@preview/suiji:0.5.1" as suiji
+
+// Global RNG state (stores the master seed integer)
+#let rng-state = state("ttt-rng", 0)
+
+/// Initialize the global random number generator with a seed.
+///
+/// - seed (int): The seed to use.
+#let init-rng(seed) = {
+  rng-state.update(seed)
 }
 
-/// shuffle an array.
+/// Shuffle an array using the global RNG state and a unique identifier.
 ///
-/// - arr (array): the array to randomize
-/// - seed (int): a seed to start with. if auto the current date will be used (default).
-/// -> array
-#let shuffle(arr, seed: auto) = arr.sorted(key: it => {
-  let now = datetime.today()
-  let rand = if (seed == auto) { int(now.year() + now.month() * 256 * now.day() * 65535) } else { seed }
-  hash(it,rand)
-})
+/// - choices (array): The array to shuffle.
+/// - id (array): A unique identifier for the shuffle context (e.g. question counter).
+#let shuffle(choices, id) = {
+  let master-seed = rng-state.get()
 
+  // Mix master seed with ID to get a deterministic local seed
+  // Assumes id is an array of integers (like a counter value)
+  let flat-idx = id.at(0) * 100 + id.at(1, default: 0)
+
+  // Simple mixing to avoid linear correlation if seeds are close
+  let local-seed = master-seed + flat-idx * 31337
+
+  let rng = suiji.gen-rng(local-seed)
+  let (_, shuffled) = suiji.shuffle(rng, choices)
+  shuffled
+}


### PR DESCRIPTION
There are currently several problems with the random module used for multiple-choice questions:
- First, the user cannot decide to manually set the order of answers. In general, I think all unremovable automatic things are not good design and can be frustrating. For example, if I'm doing true-false, I don't want it to be random.
- The function was intrinsically buggy. For example, I've seen situations in which, with four choices, the correct answer was only either at the beginning or at the end. I do not fully understand why, but I believe it has to do with bit-wise operations.
- Finally, for me it's important to create multiple versions of the same document with different answer sequences. The common use case is tests with different versions that render copying difficult.

Because dealing with stateful things in typst is very tricky, it's good to use existing code that does it. I've rewritten the code to use `suiji`, the best library available for random numbers in typst. It's now possible to
- Set a global random seed that changes the whole document, to instantly create different random versions
- Deactivate shuffling (note that in this case the user should only fill the `answers` argument, and not `distractors`)