### PR TITLE
Bump linguify to 0.5.0

### DIFF
--- a/ttt-exam/lib/i18n.typ
+++ b/ttt-exam/lib/i18n.typ
@@ -1,4 +1,4 @@
-#import "@preview/linguify:0.4.0": *
+#import "@preview/linguify:0.5.0": *
 
 // load linguify database file
 #let ling_db = toml("assets/lang.toml")


### PR DESCRIPTION
This is necessary because 0.4.0 is incompatible with Typst 0.14. So the whole ttt-exam cannot use the latest version of Typst.